### PR TITLE
Transient resource based liquidation

### DIFF
--- a/lending_market/src/lending_market.rs
+++ b/lending_market/src/lending_market.rs
@@ -30,8 +30,8 @@ pub struct CollaterizedDebtPositionUpdatedEvent {
 mod lending_market {
 
     extern_blueprint!(
-        // "package_tdx_2_1p5tmhcj8j74ulggypapmy7qafq7378tl78ks58p498erm053l8jg6j",  // stokenet
-        "package_sim1pkwaf2l9zkmake5h924229n44wp5pgckmpn0lvtucwers56awywems", // resim
+        "package_tdx_2_1p5tmhcj8j74ulggypapmy7qafq7378tl78ks58p498erm053l8jg6j",  // stokenet
+        // "package_sim1pkwaf2l9zkmake5h924229n44wp5pgckmpn0lvtucwers56awywems", // resim
         // "package_sim1p40gjy9kwhn9fjwf9jur0axx72f7c36l6tx3z3vzefp0ytczcql99n", // testing
         SingleResourcePool {
             fn instantiate(

--- a/lending_market/src/modules/cdp_health_checker.rs
+++ b/lending_market/src/modules/cdp_health_checker.rs
@@ -151,10 +151,10 @@ pub struct CDPHealthChecker {
     self_loan_to_value_ratio: Decimal,
 
     /// IndexMap of all the collateral positions in the CDP. The key is the resource address of the asset used as collateral.
-    collateral_positions: IndexMap<ResourceAddress, ExtendedCollateralPositionData>,
+    pub collateral_positions: IndexMap<ResourceAddress, ExtendedCollateralPositionData>,
 
     /// IndexMap of all the loan positions in the CDP. the key is the resource address of borrowed the asset
-    loan_positions: IndexMap<ResourceAddress, ExtendedLoanPositionData>,
+    pub loan_positions: IndexMap<ResourceAddress, ExtendedLoanPositionData>,
 }
 impl CDPHealthChecker {
     // Created an extended CDP from a CDP NFT data
@@ -204,7 +204,7 @@ impl CDPHealthChecker {
             match load_collateral {
                 LoadPositionType::Collateral => {
                     let collateral_position =
-                        extended_cdp._get_collateral_position(&mut pool_state)?;
+                        extended_cdp.get_collateral_position(&mut pool_state)?;
                     collateral_position.data.load_onledger_data(
                         units,
                         LoadDataType::Own,
@@ -213,7 +213,7 @@ impl CDPHealthChecker {
                 }
                 LoadPositionType::DelegatorCollateral => {
                     let collateral_position =
-                        extended_cdp._get_collateral_position(&mut pool_state)?;
+                        extended_cdp.get_collateral_position(&mut pool_state)?;
                     collateral_position.data.load_onledger_data(
                         units,
                         LoadDataType::Delegator,
@@ -378,7 +378,7 @@ impl CDPHealthChecker {
             .collect()
     }
 
-    fn _get_collateral_position(
+    fn get_collateral_position(
         &mut self,
         pool_state: &mut KeyValueEntryRefMut<'_, LendingPoolState>,
     ) -> Result<&mut ExtendedCollateralPositionData, String> {

--- a/lending_market/src/modules/cdp_health_checker.rs
+++ b/lending_market/src/modules/cdp_health_checker.rs
@@ -311,8 +311,6 @@ impl CDPHealthChecker {
     pub fn check_cdp(&mut self) -> Result<(), String> {
         self._update_health_check_data()?;
 
-        info!("CDP Health Check: {:?}", self.total_loan_to_value_ratio);
-
         if !(self.total_loan_to_value_ratio < Decimal::ONE) {
             return Err("LTV need to be lower 1".to_string());
         }
@@ -559,7 +557,6 @@ impl CDPHealthChecker {
             total_loan_to_value_ratio = total_loan_value / total_discounted_collateral_value;
         }
 
-        // self.total_solvency_value = total_solvency_value;
         self.self_closable_loan_value = self_closable_loan_value;
 
         self.total_loan_value = total_loan_value;

--- a/lending_market/src/modules/pool_config.rs
+++ b/lending_market/src/modules/pool_config.rs
@@ -166,9 +166,11 @@ impl PoolConfig {
 
     pub fn check_limit(&self, input: CheckPoolConfigLimitInput) -> Result<(), String> {
         match input {
-            CheckPoolConfigLimitInput::DepositLimit(deposit_limit) => {
+            CheckPoolConfigLimitInput::DepositLimit(current_deposit) => {
                 if let Some(limit) = self.deposit_limit {
-                    if deposit_limit > limit {
+                    info!("current_deposit: {:?}, limit: {:?}", current_deposit, limit);
+
+                    if current_deposit > limit {
                         return Err(
                             "Deposit limit reached. Please try again with a smaller amount.".into(),
                         );
@@ -176,9 +178,9 @@ impl PoolConfig {
                 }
             }
 
-            CheckPoolConfigLimitInput::BorrowLimit(borrow_limit) => {
+            CheckPoolConfigLimitInput::BorrowLimit(current_borrow) => {
                 if let Some(limit) = self.borrow_limit {
-                    if borrow_limit > limit {
+                    if current_borrow > limit {
                         return Err(
                             "Borrow limit reached. Please try again with a smaller amount.".into(),
                         );
@@ -186,9 +188,9 @@ impl PoolConfig {
                 }
             }
 
-            CheckPoolConfigLimitInput::UtilizationLimit(utilization_limit) => {
+            CheckPoolConfigLimitInput::UtilizationLimit(current_utilization) => {
                 if let Some(limit) = self.utilization_limit {
-                    if utilization_limit > limit {
+                    if current_utilization > limit {
                         return Err(
                             "Utilization limit reached. Please try again with a smaller amount."
                                 .into(),

--- a/lending_market/src/modules/pool_state.rs
+++ b/lending_market/src/modules/pool_state.rs
@@ -222,7 +222,12 @@ impl LendingPoolState {
 
         // Debounce price update to configured period (in minutes)
         if period_in_minute >= self.pool_config.price_update_period {
-            self.price_updated_at = now;
+            // TODO: Handle XRD price update
+            // if self.pool_res_address == XRD {
+            //     self.last_price = dec!(1);
+            //     self.price_updated_at = now;
+            //     return Ok(());
+            // }
 
             let price_feed_result = self
                 .price_feed_comp
@@ -232,8 +237,15 @@ impl LendingPoolState {
                 return Err("Price feed returned None".to_string());
             }
 
+            let price_feed_result = price_feed_result.unwrap();
+
             // TODO: Handle price update too old
-            self.last_price = price_feed_result.unwrap().price;
+            // if (now - price_feed_result.timestamp) >= self.pool_config.price_update_period {
+            //     return Err("Price feed is too old".to_string());
+            // }
+
+            self.price_updated_at = now;
+            self.last_price = price_feed_result.price;
         }
 
         /* UPDATING INTEREST RATE */

--- a/lending_market/src/modules/pool_state.rs
+++ b/lending_market/src/modules/pool_state.rs
@@ -191,7 +191,7 @@ impl LendingPoolState {
 
     /// Handle request to decrease borrowed amount.
     /// it add back liquidity and updated the pool loan state based on input interest startegy
-    pub fn deposit_from_repay(&mut self, payment: Bucket) -> Result<Decimal, String> {
+    pub fn deposit_for_repay(&mut self, payment: Bucket) -> Result<Decimal, String> {
         if payment.resource_address() != self.pool_res_address {
             return Err("Payment resource address missmatch".into());
         }

--- a/lending_market/src/resources.rs
+++ b/lending_market/src/resources.rs
@@ -15,6 +15,11 @@ pub struct BatchFlashloanTerm {
     pub terms: IndexMap<ResourceAddress, BatchFlashloanItem>,
 }
 
+#[derive(ScryptoSbor, NonFungibleData)]
+pub struct LiquidationTerm {
+    pub payement_value: Decimal,
+}
+
 pub fn create_admin_badge(
     owner_rule: AccessRule,
     address_reservation: GlobalAddressReservation,
@@ -74,6 +79,34 @@ pub fn create_cdp_res_manager(
 }
 
 pub fn create_batch_flashloan_term_res_manager(
+    owner_rule: AccessRule,
+    component_rule: AccessRule,
+) -> ResourceManager {
+    ResourceBuilder::new_ruid_non_fungible::<BatchFlashloanTerm>(OwnerRole::None)
+        .metadata(metadata!(
+            roles {
+                metadata_setter => owner_rule.clone();
+                metadata_setter_updater => owner_rule.clone();
+                metadata_locker => owner_rule.clone();
+                metadata_locker_updater => owner_rule.clone();
+            }
+        ))
+        .mint_roles(mint_roles! {
+            minter => component_rule.clone();
+            minter_updater => rule!(deny_all);
+        })
+        .burn_roles(burn_roles! {
+            burner => component_rule.clone();
+            burner_updater => rule!(deny_all);
+        })
+        .deposit_roles(deposit_roles! {
+            depositor => rule!(deny_all);
+            depositor_updater => rule!(deny_all);
+        })
+        .create_with_no_initial_supply()
+}
+
+pub fn create_liquidation_term_res_manager(
     owner_rule: AccessRule,
     component_rule: AccessRule,
 ) -> ResourceManager {

--- a/lending_market/src/resources.rs
+++ b/lending_market/src/resources.rs
@@ -17,6 +17,7 @@ pub struct BatchFlashloanTerm {
 
 #[derive(ScryptoSbor, NonFungibleData)]
 pub struct LiquidationTerm {
+    pub cdp_id: NonFungibleLocalId,
     pub payement_value: Decimal,
 }
 
@@ -110,7 +111,7 @@ pub fn create_liquidation_term_res_manager(
     owner_rule: AccessRule,
     component_rule: AccessRule,
 ) -> ResourceManager {
-    ResourceBuilder::new_ruid_non_fungible::<BatchFlashloanTerm>(OwnerRole::None)
+    ResourceBuilder::new_ruid_non_fungible::<LiquidationTerm>(OwnerRole::None)
         .metadata(metadata!(
             roles {
                 metadata_setter => owner_rule.clone();


### PR DESCRIPTION
This pull request introduces a new feature to the liquidation process: a temporary 'Liquidation Term.' The liquidation kicks off with the withdrawal of collateral and the issuance of a Liquidation Term, which details the value of this collateral. The liquidator then receives both the collateral and the Liquidation Term, and they are allowed to utilize the collateral as they deem suitable. This could involve trading on a decentralized exchange or contributing to a liquidation pool to obtain funds that match the Liquidation Term's recorded value. Once the liquidator secures the equivalent funds, they can complete the liquidation process by calling a dedicated method. This method not only repays the loan but also burns the Liquidation Term, effectively removing it from the system. It's critical to remember that Liquidation Terms must be burned within the transaction's lifetime; otherwise, the transaction will not complete. Furthermore, the authority to burn the Liquidation Term resides exclusively with the LendingMarket component.